### PR TITLE
Update Generic.Files.xml

### DIFF
--- a/source/phpcs/Generic.Files.xml
+++ b/source/phpcs/Generic.Files.xml
@@ -41,7 +41,7 @@ To turn of $absoluteLineLimit '0' can be used.
     </description>
     <properties>
       <property name="lineLimit" description="Lines longer than this value will raising a warning" value="80"/>
-      <property name="absoluteLineLimit" description="Lines longer than this value will raising an error" value="120"/>
+      <property name="absoluteLineLimit" description="Lines longer than this value will raising an error" value="100"/>
     </properties>
   </rule>
 


### PR DESCRIPTION
The default for LineLength seems to be 80/100 instead of 80/120. I recently added a scrutinizer file to one of my projects with just this line:

    <rule ref="Generic.Files.LineLength"/>

assuming that it would use the 120 absolute limit shown in the UI. But instead it would report violations at 100 already.

Compare with https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Generic/Sniffs/Files/LineLengthSniff.php